### PR TITLE
ENH: Add some support for Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # Darkdetect
 
-This package allows to detect if the user is using Dark Mode ([macOS 10.14+](https://support.apple.com/en-us/HT208976) or [Windows 10 1607+](https://blogs.windows.com/windowsexperience/2016/08/08/windows-10-tip-personalize-your-pc-by-enabling-the-dark-theme/)). The main application of this package is to detect the Dark mode from your GUI Python application (Tkinter/wx/pyqt/qt for python (pyside)/...) and apply the needed adjustments to your interface. Darkdetect is particularly useful if your GUI library **does not** provide a public API for this detection (I am looking at you, Qt). In addition, this package does not depend on other modules or packages that are not already included in standard Python distributions.
+This package allows to detect if the user is using Dark Mode on:
+
+- ([macOS 10.14+](https://support.apple.com/en-us/HT208976)
+- [Windows 10 1607+](https://blogs.windows.com/windowsexperience/2016/08/08/windows-10-tip-personalize-your-pc-by-enabling-the-dark-theme/))
+- Linux with [a dark GTK theme](https://www.gnome-look.org/browse/cat/135/ord/rating/?tag=dark) on an **experimental** basis (see notes below)
+
+The main application of this package is to detect the Dark mode from your GUI Python application (Tkinter/wx/pyqt/qt for python (pyside)/...) and apply the needed adjustments to your interface. Darkdetect is particularly useful if your GUI library **does not** provide a public API for this detection (I am looking at you, Qt). In addition, this package does not depend on other modules or packages that are not already included in standard Python distributions.
 
 
 ## Usage
@@ -33,3 +39,4 @@ Alternatively, you are free to vendor directly a copy of Darkdetect in your app.
 - This software is licensed under the terms of the 3-clause BSD License.
 - This package can be installed on any operative system, but it will always return `None` unless executed on a version of macOS or Windows that supports Dark Mode. This package is designed to work also with older versions of macOS and Windows and in those cases it will also return `None`. Detection of the dark menu bar and dock option (available from macOS 10.10) is not supported.
 - [Details](https://stackoverflow.com/questions/25207077/how-to-detect-if-os-x-is-in-dark-mode) on the detection method used on macOS.
+- [Details](https://askubuntu.com/questions/1261366/detecting-dark-mode#comment2132694_1261366) on the experimental detection method used on Linux, which just attempts to check if the GTK theme ends in `'-dark'` by making a call to `gsettings`.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This package allows to detect if the user is using Dark Mode on:
 
 - ([macOS 10.14+](https://support.apple.com/en-us/HT208976)
 - [Windows 10 1607+](https://blogs.windows.com/windowsexperience/2016/08/08/windows-10-tip-personalize-your-pc-by-enabling-the-dark-theme/))
-- Linux with [a dark GTK theme](https://www.gnome-look.org/browse/cat/135/ord/rating/?tag=dark) on an **experimental** basis (see notes below)
+- Linux with [a dark GTK theme](https://www.gnome-look.org/browse/cat/135/ord/rating/?tag=dark).
 
 The main application of this package is to detect the Dark mode from your GUI Python application (Tkinter/wx/pyqt/qt for python (pyside)/...) and apply the needed adjustments to your interface. Darkdetect is particularly useful if your GUI library **does not** provide a public API for this detection (I am looking at you, Qt). In addition, this package does not depend on other modules or packages that are not already included in standard Python distributions.
 
@@ -39,4 +39,4 @@ Alternatively, you are free to vendor directly a copy of Darkdetect in your app.
 - This software is licensed under the terms of the 3-clause BSD License.
 - This package can be installed on any operative system, but it will always return `None` unless executed on a version of macOS or Windows that supports Dark Mode. This package is designed to work also with older versions of macOS and Windows and in those cases it will also return `None`. Detection of the dark menu bar and dock option (available from macOS 10.10) is not supported.
 - [Details](https://stackoverflow.com/questions/25207077/how-to-detect-if-os-x-is-in-dark-mode) on the detection method used on macOS.
-- [Details](https://askubuntu.com/questions/1261366/detecting-dark-mode#comment2132694_1261366) on the experimental detection method used on Linux, which just attempts to check if the GTK theme ends in `'-dark'` by making a call to `gsettings`.
+- [Details](https://askubuntu.com/questions/1261366/detecting-dark-mode#comment2132694_1261366) on the experimental detection method used on Linux.

--- a/darkdetect/__init__.py
+++ b/darkdetect/__init__.py
@@ -24,6 +24,8 @@ elif sys.platform == "win32" and platform.release() == "10":
         from ._windows_detect import *
     else:
         from ._dummy import *
+elif sys.platform == "linux":
+    from ._linux_detect import *
 else:
     from ._dummy import *
 

--- a/darkdetect/_linux_detect.py
+++ b/darkdetect/_linux_detect.py
@@ -1,0 +1,37 @@
+#-----------------------------------------------------------------------------
+#  Copyright (C) 2019 Alberto Sottile
+#
+#  Distributed under the terms of the 3-clause BSD License.
+#-----------------------------------------------------------------------------
+
+import subprocess
+
+
+def theme():
+    # Here we just triage to GTK settings for now
+    try:
+        proc = subprocess.run(
+            ['gsettings', 'get', 'org.gnome.desktop.interface',
+             'gtk-theme'], capture_output=True)
+        theme = proc.stdout.decode().strip().strip("'")
+    except Exception:
+        return None
+    else:
+        if theme.endswith('-dark'):
+            return 'Dark'
+        else:
+            return 'Light'
+
+def isDark():
+    got = theme()
+    if got is None:
+        return None
+    else:
+        return theme() == 'Dark'
+
+def isLight():
+    got = theme()
+    if got is None:
+        return None
+    else:
+        return theme() == 'Light'

--- a/darkdetect/_linux_detect.py
+++ b/darkdetect/_linux_detect.py
@@ -4,16 +4,18 @@
 #  Distributed under the terms of the 3-clause BSD License.
 #-----------------------------------------------------------------------------
 
-import subprocess
+from ctypes import util, cdll, c_char_p, byref
 
 
 def theme():
     # Here we just triage to GTK settings for now
     try:
-        proc = subprocess.run(
-            ['gsettings', 'get', 'org.gnome.desktop.interface',
-             'gtk-theme'], capture_output=True)
-        theme = proc.stdout.decode().strip().strip("'")
+        gtklib = cdll.LoadLibrary(util.find_library('gtk-3'))
+        gtklib.gtk_init(None, None)
+        settings = gtklib.gtk_settings_get_default()
+        res = c_char_p()
+        gtklib.g_object_get(settings, b"gtk-theme-name", byref(res), 0)
+        theme = res.value.decode()
     except Exception:
         return 'Light'
     else:

--- a/darkdetect/_linux_detect.py
+++ b/darkdetect/_linux_detect.py
@@ -1,5 +1,5 @@
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2019 Alberto Sottile
+#  Copyright (C) 2019 Alberto Sottile, Eric Larson
 #
 #  Distributed under the terms of the 3-clause BSD License.
 #-----------------------------------------------------------------------------
@@ -15,7 +15,7 @@ def theme():
              'gtk-theme'], capture_output=True)
         theme = proc.stdout.decode().strip().strip("'")
     except Exception:
-        return None
+        return 'Light'
     else:
         if theme.endswith('-dark'):
             return 'Dark'
@@ -23,15 +23,7 @@ def theme():
             return 'Light'
 
 def isDark():
-    got = theme()
-    if got is None:
-        return None
-    else:
-        return theme() == 'Dark'
+    return theme() == 'Dark'
 
 def isLight():
-    got = theme()
-    if got is None:
-        return None
-    else:
-        return theme() == 'Light'
+    return theme() == 'Light'


### PR DESCRIPTION
I tried to match local conventions and update the README, let me know if it makes sense and seems worthwhile! At least on Ubuntu 20.10 with Adiwata-dark on GTK I get:
```
$ python -c "import darkdetect; print(darkdetect.theme())"
Dark
```
Closes #7