### PR TITLE
FIX: Avoid segfaults

### DIFF
--- a/darkdetect/_linux_detect.py
+++ b/darkdetect/_linux_detect.py
@@ -4,25 +4,20 @@
 #  Distributed under the terms of the 3-clause BSD License.
 #-----------------------------------------------------------------------------
 
-from ctypes import util, cdll, c_char_p, byref
+import subprocess
 
 
 def theme():
     # Here we just triage to GTK settings for now
-    try:
-        gtklib = cdll.LoadLibrary(util.find_library('gtk-3'))
-        gtklib.gtk_init(None, None)
-        settings = gtklib.gtk_settings_get_default()
-        res = c_char_p()
-        gtklib.g_object_get(settings, b"gtk-theme-name", byref(res), 0)
-        theme = res.value.decode()
-    except Exception:
-        return 'Light'
+    out = subprocess.Popen(
+        ['gsettings', 'get', 'org.gnome.desktop.interface', 'gtk-theme'],
+        stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    stdout, _ = out.communicate()
+    theme = stdout.lower().decode().strip()[1:-1]  # remove start and end quote
+    if theme.endswith('-dark'):
+        return 'Dark'
     else:
-        if theme.endswith('-dark'):
-            return 'Dark'
-        else:
-            return 'Light'
+        return 'Light'
 
 def isDark():
     return theme() == 'Dark'

--- a/darkdetect/_linux_detect.py
+++ b/darkdetect/_linux_detect.py
@@ -9,11 +9,15 @@ import subprocess
 
 def theme():
     # Here we just triage to GTK settings for now
-    out = subprocess.Popen(
-        ['gsettings', 'get', 'org.gnome.desktop.interface', 'gtk-theme'],
-        stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-    stdout, _ = out.communicate()
-    theme = stdout.lower().decode().strip()[1:-1]  # remove start and end quote
+    try:
+        out = subprocess.run(
+            ['gsettings', 'get', 'org.gnome.desktop.interface', 'gtk-theme'],
+            capture_output=True)
+        stdout = out.stdout.decode()
+    except Exception:
+        return 'Light'
+    # we have a string, now remove start and end quote
+    theme = stdout.lower().strip()[1:-1]
     if theme.endswith('-dark'):
         return 'Dark'
     else:


### PR DESCRIPTION
Similar to @HetDaftary I also see problems when using `darkdetect` as part of a Qt application in Linux:
```
Current thread 0x00007f4e2f45e740 (most recent call first):
  File "/home/larsoner/python/darkdetect/darkdetect/_linux_detect.py", line 17 in theme
  File "/home/larsoner/python/mne-python/mne/viz/backends/_qt.py", line 533 in _detect_theme
  File "/home/larsoner/python/mne-python/mne/viz/backends/_qt.py", line 445 in _window_set_theme
  File "/home/larsoner/python/mne-python/mne/viz/_brain/_brain.py", line 483 in __init__
  File "/home/larsoner/python/mne-python/mne/viz/_3d.py", line 1862 in _plot_stc
  File "/home/larsoner/python/mne-python/mne/viz/_3d.py", line 1780 in plot_source_estimates
  File "<decorator-gen-153>", line 24 in plot_source_estimates
  File "/home/larsoner/python/mne-python/mne/source_estimate.py", line 651 in plot
  File "/home/larsoner/Desktop/plot_dics.py", line 126 in plot_approach
  File "/home/larsoner/Desktop/plot_dics.py", line 138 in <module>
Segmentation fault (core dumped)
```
I just tried using `multiprocessing` and still see segfaults. On this branch I don't get segfaults. So it seems that initializing / using GTK at the same time as Qt can be problematic, so this solution seems safer.