### PR TITLE
Use absolute paths for libraries on Big Sur

### DIFF
--- a/darkdetect/_mac_detect.py
+++ b/darkdetect/_mac_detect.py
@@ -14,8 +14,8 @@ if V(platform.mac_ver()[0]) < V("10.16") or platform.python_version_tuple()[0] =
     appkit = ctypes.cdll.LoadLibrary(ctypes.util.find_library('AppKit'))
     objc = ctypes.cdll.LoadLibrary(ctypes.util.find_library('objc'))
 else:
-    appkit = ctypes.cdll.LoadLibrary('AppKit.framework/AppKit')
-    objc = ctypes.cdll.LoadLibrary('libobjc.dylib')
+    appkit = ctypes.cdll.LoadLibrary('/System/Library/Frameworks/AppKit.framework/AppKit')
+    objc = ctypes.cdll.LoadLibrary('/usr/lib/libobjc.dylib')
 del V
 
 void_p = ctypes.c_void_p


### PR DESCRIPTION
When using darkdetect 0.4.0-0.5.0 within an application on MacOS (in my case, in a Blender add-on), it would give the error `OSError: dlopen(AppKit.framework/AppKit, 6): no suitable image found.  Did find: file system relative paths not allowed in hardened programs` from line 17 of `_mac_detect.py`.

I’m not sure if this is best practice, but I changed the paths in line 17-18 `_mac_detect.py` to absolute paths, which seems to have fixed the error and allows darkdetect to be used both from the command line and within Blender. I have only tested this fix on Big Sur 11.6 on both Intel and M1, not on any other version.