### PR TITLE
Added precautionary support for windows 11

### DIFF
--- a/darkdetect/__init__.py
+++ b/darkdetect/__init__.py
@@ -16,7 +16,7 @@ if sys.platform == "darwin":
     else:
         from ._mac_detect import *
     del V
-elif sys.platform == "win32" and platform.release() >= "10":
+elif sys.platform == "win32" and int(platform.release()) >= 10:
     # Checks if running Windows 10 version 10.0.14393 (Anniversary Update) OR HIGHER. The getwindowsversion method returns a tuple.
     # The third item is the build number that we can use to check if the user has a new enough version of Windows.
     winver = int(sys.getwindowsversion()[2])

--- a/darkdetect/__init__.py
+++ b/darkdetect/__init__.py
@@ -16,8 +16,8 @@ if sys.platform == "darwin":
     else:
         from ._mac_detect import *
     del V
-elif sys.platform == "win32" and platform.release() == "10":
-    # Checks if running Windows 10 version 10.0.14393 (Anniversary Update) or higher. The getwindowsversion method returns a tuple.
+elif sys.platform == "win32" and platform.release() >= "10":
+    # Checks if running Windows 10 version 10.0.14393 (Anniversary Update) OR HIGHER. The getwindowsversion method returns a tuple.
     # The third item is the build number that we can use to check if the user has a new enough version of Windows.
     winver = int(sys.getwindowsversion()[2])
     if winver >= 14393:


### PR DESCRIPTION
This is done to prevent any hassle, if Microsoft ever decides to bump the major version for windows 11 to "11" from "10" _(which seems quite logical)_