### PR TITLE
Solved the problem with themes like Sweet-Dark-v40 

### DIFF
--- a/darkdetect/_linux_detect.py
+++ b/darkdetect/_linux_detect.py
@@ -18,7 +18,7 @@ def theme():
         return 'Light'
     # we have a string, now remove start and end quote
     theme = stdout.lower().strip()[1:-1]
-    if theme.endswith('-dark'):
+    if 'dark' in theme.lower():
         return 'Dark'
     else:
         return 'Light'


### PR DESCRIPTION
The original code needs the theme name to end with '-dark' and all dark theme names do not end with '-dark'.
For example, Matcha-dark-sea or Sweet-Dark-v40 create a problem with the original code has the code detects them as light theme and not dark theme.
I have fixed this by finding 'dark' in the theme after converting the theme name to lower case.