### PR TITLE
Avoid ValueError on Windows Server (and others)

### DIFF
--- a/darkdetect/__init__.py
+++ b/darkdetect/__init__.py
@@ -16,7 +16,7 @@ if sys.platform == "darwin":
     else:
         from ._mac_detect import *
     del V
-elif sys.platform == "win32" and int(platform.release()) >= 10:
+elif sys.platform == "win32" and platform.release().isdigit() and int(platform.release()) >= 10:
     # Checks if running Windows 10 version 10.0.14393 (Anniversary Update) OR HIGHER. The getwindowsversion method returns a tuple.
     # The third item is the build number that we can use to check if the user has a new enough version of Windows.
     winver = int(platform.version().split('.')[2])


### PR DESCRIPTION
This changes avoids throwing a ValueError when trying to convert platform.release() into an integer (platform.release() does not necessarily return an integer: on Windows Server 2008 R2, it returns '2008ServerR2' for example).