### PR TITLE
Update _linux_detect.py to support freedesktop standard on gnome

### DIFF
--- a/darkdetect/_linux_detect.py
+++ b/darkdetect/_linux_detect.py
@@ -8,12 +8,18 @@ import subprocess
 import typing
 
 def theme():
-    # Here we just triage to GTK settings for now
     try:
+        #Using the freedesktop specifications for checking dark mode
         out = subprocess.run(
-            ['gsettings', 'get', 'org.gnome.desktop.interface', 'gtk-theme'],
+            ['gsettings', 'get', 'org.gnome.desktop.interface', 'color-scheme'],
             capture_output=True)
         stdout = out.stdout.decode()
+        #If not found then trying older gtk-theme method
+        if len(stdout)<1:
+            out = subprocess.run(
+                ['gsettings', 'get', 'org.gnome.desktop.interface', 'gtk-theme'],
+                capture_output=True)
+            stdout = out.stdout.decode()
     except Exception:
         return 'Light'
     # we have a string, now remove start and end quote


### PR DESCRIPTION
The original code only used the names of gtk-themes for checking of dark mode. Now, I have added support for the new freedesktop standard for checking dark mode in gnome as newer versions of gnome use this for setting dark mode