### PR TITLE
Linux: generalise detection to any theme with 'dark' in the name

### DIFF
--- a/darkdetect/_linux_detect.py
+++ b/darkdetect/_linux_detect.py
@@ -18,7 +18,7 @@ def theme():
         return 'Light'
     # we have a string, now remove start and end quote
     theme = stdout.lower().strip()[1:-1]
-    if theme.endswith('-dark'):
+    if 'dark' in theme.lower():
         return 'Dark'
     else:
         return 'Light'
@@ -36,4 +36,4 @@ def listener(callback: typing.Callable[[str], None]) -> None:
         universal_newlines=True,
     ) as p:
         for line in p.stdout:
-            callback('Dark' if line.strip().removeprefix("gtk-theme: '").removesuffix("'").endswith('-dark') else 'Light')
+            callback('Dark' if 'dark' in line.strip().removeprefix("gtk-theme: '").removesuffix("'").lower() else 'Light')

--- a/darkdetect/_linux_detect.py
+++ b/darkdetect/_linux_detect.py
@@ -18,7 +18,7 @@ def theme():
         return 'Light'
     # we have a string, now remove start and end quote
     theme = stdout.lower().strip()[1:-1]
-    if 'dark' in theme.lower():
+    if '-dark' in theme.lower():
         return 'Dark'
     else:
         return 'Light'
@@ -36,4 +36,4 @@ def listener(callback: typing.Callable[[str], None]) -> None:
         universal_newlines=True,
     ) as p:
         for line in p.stdout:
-            callback('Dark' if 'dark' in line.strip().removeprefix("gtk-theme: '").removesuffix("'").lower() else 'Light')
+            callback('Dark' if '-dark' in line.strip().removeprefix("gtk-theme: '").removesuffix("'").lower() else 'Light')


### PR DESCRIPTION
This is an extension to #17 and fixes the same issue in `listener()`. We consider any theme with `'dark' in theme.lower()` to be a dark theme.

There is no official standard for theme names, and the suffix approach is often flawed. By convention, most dark themes will have 'dark' somewhere in their name, and only a very tiny minority of light themes will have 'dark' in their name, so there should be almost 0 instances of a light theme being called dark, whereas currently, many dark themes are incorrectly called light.