### PR TITLE
Naive listener for macOS

### DIFF
--- a/darkdetect/_mac_detect.py
+++ b/darkdetect/_mac_detect.py
@@ -4,6 +4,8 @@
 #  Distributed under the terms of the 3-clause BSD License.
 #-----------------------------------------------------------------------------
 
+import time
+
 import ctypes
 import ctypes.util
 
@@ -71,4 +73,12 @@ def isLight():
 
 #def listener(callback: typing.Callable[[str], None]) -> None:
 def listener(callback):
-    raise NotImplementedError()
+    # This is a very naive approach
+    delay = 0.05
+    old = theme()
+    while True:
+        new = theme()
+        if new != old:
+            old = new
+            callback(new)
+        time.sleep(delay)

--- a/darkdetect/_mac_detect.py
+++ b/darkdetect/_mac_detect.py
@@ -72,9 +72,14 @@ def isLight():
     return theme() == 'Light'
 
 #def listener(callback: typing.Callable[[str], None]) -> None:
-def listener(callback):
+def listener(callback, *, delay = 0.05):
+    """
+    A naive listener for macOS
+    :param callback: When the theme changes, callback(theme()) is invoked
+    :param delay: The number of seconds to between checking if the theme changed
+    :return: None
+    """
     # This is a very naive approach
-    delay = 0.05
     old = theme()
     while True:
         new = theme()


### PR DESCRIPTION
Add a naive macOS listener.

Small demo, toggling mode after starting thread:
```python
>>> import darkdetect
>>> import threading
>>> t=threading.Thread(target=darkdetect.listener, args=(print,))
>>> t.start()
>>> Dark
Light
>>>
>>> [1]    13336 quit       python3
```