### PR TITLE
Implement a macOS listener

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Alternatively, you are free to vendor directly a copy of Darkdetect in your app.
 
 To enable the macOS listener, additional components are required, these can be installed via:
 ```bash
-pip install -e darkdetect[macos-listener]
+pip install darkdetect[macos-listener]
 ```
 
 ## Notes

--- a/README.md
+++ b/README.md
@@ -49,6 +49,13 @@ pip install darkdetect
 
 Alternatively, you are free to vendor directly a copy of Darkdetect in your app. Further information on vendoring can be found [here](https://medium.com/underdog-io-engineering/vendoring-python-dependencies-with-pip-b9eb6078b9c0).
 
+## Optional Installs
+
+To enable the macOS listener, additional components are required, these can be installed via:
+```bash
+pip install -e darkdetect[macos-listener]
+```
+
 ## Notes
 
 - This software is licensed under the terms of the 3-clause BSD License.

--- a/darkdetect/__init__.py
+++ b/darkdetect/__init__.py
@@ -4,7 +4,7 @@
 #  Distributed under the terms of the 3-clause BSD License.
 #-----------------------------------------------------------------------------
 
-__version__ = '0.7.1'
+__version__ = '0.8.0'
 
 import sys
 import platform

--- a/darkdetect/__init__.py
+++ b/darkdetect/__init__.py
@@ -4,7 +4,7 @@
 #  Distributed under the terms of the 3-clause BSD License.
 #-----------------------------------------------------------------------------
 
-__version__ = '0.8.0'
+__version__ = '0.7.1'
 
 import sys
 import platform

--- a/darkdetect/_mac_detect.py
+++ b/darkdetect/_mac_detect.py
@@ -8,7 +8,6 @@ import ctypes
 import ctypes.util
 import subprocess
 import sys
-import os
 from pathlib import Path
 from typing import Callable
 

--- a/darkdetect/_mac_detect.py
+++ b/darkdetect/_mac_detect.py
@@ -107,12 +107,12 @@ def listener(callback: Callable[[str], None]) -> None:
     if not _can_listen:
         raise NotImplementedError()
     sig = "import signal as s; s.signal(s.SIGINT, s.SIG_IGN)"
-    listen = "import darkdetect as dd; dd._mac_detect._listen_child()"
+    listen = "import _mac_detect as m; m._listen_child()"
     with subprocess.Popen(
         (sys.executable, "-c", f"{sig}; {listen}"),
         stdout=subprocess.PIPE,
         universal_newlines=True,
-        cwd=Path(__file__).parents[1],
+        cwd=Path(__file__).parent,
     ) as p:
         for line in p.stdout:
             callback(line.strip())

--- a/darkdetect/_mac_detect.py
+++ b/darkdetect/_mac_detect.py
@@ -134,4 +134,6 @@ class MPListener:
 
 #def listener(callback: typing.Callable[[str], None]) -> None:
 def listener(callback):
+    if not _can_listen:
+        raise NotImplementedError()
     MPListener().listen(callback)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 name = "darkdetect"
 description = "Detect OS Dark Mode from Python"
 readme = "README.md"
-requires-python = ">=3"
+requires-python = ">=3.6"
 dynamic = [ "version" ]
 classifiers = [
     "License :: OSI Approved :: BSD License",
@@ -16,7 +16,6 @@ classifiers = [
     "Operating System :: Microsoft :: Windows :: Windows 10",
     "Operating System :: POSIX :: Linux",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.5",
     "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
@@ -34,6 +33,9 @@ email = "asottile@gmail.com"
 [project.urls]
 homepage = "http://github.com/albertosottile/darkdetect"
 download = "http://github.com/albertosottile/darkdetect/releases"
+
+[project.optional-dependencies]
+mac_listener = [ "pyobjc-framework-Cocoa; platform_system == 'Darwin'" ]
 
 # Tool Config
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ homepage = "http://github.com/albertosottile/darkdetect"
 download = "http://github.com/albertosottile/darkdetect/releases"
 
 [project.optional-dependencies]
-mac_listener = [ "pyobjc-framework-Cocoa; platform_system == 'Darwin'" ]
+macos-listener = [ "pyobjc-framework-Cocoa; platform_system == 'Darwin'" ]
 
 # Tool Config
 


### PR DESCRIPTION
Implements: https://github.com/albertosottile/darkdetect/issues/25

UPDATED: This PR:
1. Adds a macOS listener; this listener requires `pip install darkdetect[mac_listener]`; if the extra `mac_listener` is not installed, the listener raises `NotImpelementedError`
2. Bumps minor version to `0.8.0` as a feature has been added.
3. Drops python2 support, as per: https://github.com/albertosottile/darkdetect/pull/28#issuecomment-1339961348