### PR TITLE
Implement Listener Class

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,12 +48,12 @@ The `darkdetect.Listener` class exposes the following methods / members:
 
 ##### `.__init__(callback: Optional[Callable[[str], None]])`
 
-The construct simply sets `.callback` to the given callback argument
+The constructor simply sets `.callback` to the given callback argument
 
 ##### `.callback: Optional[Callable[[str], None]]`
 
 The callback function that the listener uses.
-The function will be called with string "Dark" or "Light" when the OS
+This function will be passed "Dark" or "Light" when the theme is changed.
 It is safe to change this during program execution.
 It is safe to set this value to `None`, while the listener will still be active,
 theme changes will not invoke the callback; though running callbacks will not be interrupted.
@@ -145,7 +145,7 @@ def shutdown(self):
 		self.logger.exception("Failed to shutdown listener within 10 seconds, quitting anyway.")
 ```
 
-##### Super simple example of wrapper `listener` function:
+##### Example of wrapper `listener` function:
 ```python
 import threading
 import darkdetect
@@ -159,7 +159,7 @@ t.start()
 1. On macOS, detection of the dark menu bar and dock option (available from macOS 10.10) is not supported.
 1. On macOS, using the listener API in a bundled app where `sys.executable` is not a python interpreter (such as pyinstaller builds), is not supported.
 1. On Windows, the after `Listener.stop(None)` is not supported as it may not die until another theme change is detected.
-Future invcations of `callback` will not be made, but the listener itself will persist.
+Future invocations of `callback` will not be made, but the listener itself will persist.
 
 ## Notes
 

--- a/README.md
+++ b/README.md
@@ -117,18 +117,16 @@ listener.wait()
 
 ##### Possible GUI app shutdown sequence
 ```python
-...
-
-def shutdown():
-  listener.stop() # Initiate stop, allows callbacks to continue running
-  other_shutdown_methods() # Stop other processes
+def shutdown(self):
+  self.listener.stop() # Initiate stop, allows callbacks to continue running
+  self.other_shutdown_methods() # Stop other processes
 
   # Wait a bit longer for callbacks to complete and listener to clean up
   try:
-    listener.wait(timeout = 10)  # This app has long callbacks, shutdown should be fast though!
-  except DarkDetect.DDTimeoutError as e:
-    # Log that callbacks are still running but we are quitting anyway
-    logger.exception(e)
+    self.listener.wait(timeout = 10)  # This app has long callbacks, shutdown should be fast though!
+  except darkdetect.DDTimeoutError as e:
+    # Log that callbacks are still running but that we are quitting anyway
+    self.logger.exception(e)
 ```
 
 ##### Super simple example of wrapper `listener` function:

--- a/README.md
+++ b/README.md
@@ -47,28 +47,18 @@ This API is exposed primarily via a `Listener` class.
 Detailed API documentation can be found [here](docs/api.md).
 For a quick overview: the `darkdetect.Listener` class exposes the following methods / members:
 
-##### `.__init__(callback: Optional[Callable[[str], None]])`
-The constructor simply sets `.callback` to the given callback argument
-
-##### `.callback: Optional[Callable[[str], None]]`
-The settable callback function that the listener uses; it will be passed "Dark" or "Light" when the theme is changed.
-
-##### `.listen()`
-This starts listening for theme changes, it will invoke
+1. `.__init__(callback: Optional[Callable[[str], None]])`: The constructor simply sets `.callback` to the given callback argument
+1. `.callback: Optional[Callable[[str], None]]`: The settable callback function that the listener uses; it will be passed "Dark" or "Light" when the theme is changed.
+1. `.listen()`: This starts listening for theme changes, it will invoke
 `self.callback(theme_name)` when a change is detected.
-
-##### `.stop(timeout: Optional[int]) -> bool`
-
+1. `.stop(timeout: Optional[int]) -> bool`: 
 This function attempts to stop the listener,
 waiting at most `timeout` seconds (`None` means infinite),
 returning `True` on success, `False` on timeout.
-
 Regardless of the result, after `.stop` returns, theme changes 
 will no longer trigger `callback`, though running callbacks will
 not be interrupted.
-
-`.stop` may safely be re-invoked any number of times.
-`.listen()` may not be called until a call to `.stop` succeeds.
+`.stop` may safely be re-invoked any number of times, but must succeed at before re-calling `.listen()`.
 
 ##### Wrapper Function
 

--- a/README.md
+++ b/README.md
@@ -89,8 +89,6 @@ The two primary use cases for `stop` with a timeout are:
 2. To restart the existing listener; a listener's `.listen()` function
 may only be re-invoked if a call to `.stop` has returned `True`.
 
-Warning: `stop(None)` may hang if the listener cannot be interrupted until another theme change is detected.
-
 ##### Wrapper Function
 
 The simplest method of using this API is the `darkdetect.listener` function, which takes a callback function as an argument.
@@ -130,7 +128,8 @@ while txt != "quit":
 listener.stop(0)
 
 print("Waiting for running callbacks to complete and the listener to terminate")
-listener.stop(None)
+if not listener.stop(timeout=5):
+	print("Callbacks / listener are still running after 5 seconds!")
 ```
 
 ##### Possible GUI app shutdown sequence
@@ -159,7 +158,8 @@ t.start()
 
 1. On macOS, detection of the dark menu bar and dock option (available from macOS 10.10) is not supported.
 1. On macOS, using the listener API in a bundled app where `sys.executable` is not a python interpreter (such as pyinstaller builds), is not supported.
-1. On Windows, the after `Listener.stop` is invoked and running callbacks complete, future callbacks should not be made, but the listener itself will not die until another theme change; that is `.wait()` will hang until another theme change.
+1. On Windows, the after `Listener.stop(None)` is not supported as it may not die until another theme change is detected.
+Future invcations of `callback` will not be made, but the listener itself will persist.
 
 ## Notes
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ pip install darkdetect[macos-listener]
 ## Notes
 
 - This software is licensed under the terms of the 3-clause BSD License.
-- This package can be installed on any operative system, but it will always return `None` unless executed on a OS that supports Dark Mode, including older versions of macOS and Windows.
+- This package can be installed on any operative system, but `theme()`, `isDark()`, and `isLight()` will always return `None` unless executed on a OS that supports Dark Mode, including older versions of macOS and Windows.
 - On macOS, detection of the dark menu bar and dock option (available from macOS 10.10) is not supported.
 - [Details](https://stackoverflow.com/questions/25207077/how-to-detect-if-os-x-is-in-dark-mode) on the detection method used on macOS.
 - [Details](https://askubuntu.com/questions/1261366/detecting-dark-mode#comment2132694_1261366) on the experimental detection method used on Linux.

--- a/README.md
+++ b/README.md
@@ -143,5 +143,6 @@ t.start()
 - This software is licensed under the terms of the 3-clause BSD License.
 - This package can be installed on any operative system, but `theme()`, `isDark()`, and `isLight()` will always return `None` unless executed on a OS that supports Dark Mode, including older versions of macOS and Windows.
 - On macOS, detection of the dark menu bar and dock option (available from macOS 10.10) is not supported.
+- On Windows, the after `Listener.stop()` is invoked and running callbacks complete, future callbacks should not be made, but the listener itself will not die until another theme change; that is `.wait()` will hang until another theme change. _PRs fixing this are welcome._
 - [Details](https://stackoverflow.com/questions/25207077/how-to-detect-if-os-x-is-in-dark-mode) on the detection method used on macOS.
 - [Details](https://askubuntu.com/questions/1261366/detecting-dark-mode#comment2132694_1261366) on the experimental detection method used on Linux.

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ if not listener.stop(timeout=5):
 ## Known Issues
 
 1. On macOS, detection of the dark menu bar and dock option (available from macOS 10.10) is not supported.
-1. On macOS, using the listener API in a bundled app where `sys.executable` is not a python interpreter (such as pyinstaller builds), is not supported.
+1. On macOS, using the listener API in a bundled app where `sys.executable` is not a python interpreter is not supported (though it may still work as it uses the same code path as `multiprocessing`).
 1. On Windows, the after `Listener.stop(None)` is not supported as it may not die until another theme change is detected.
 Future invocations of `callback` will not be made, but the listener itself will persist.
 

--- a/darkdetect/__init__.py
+++ b/darkdetect/__init__.py
@@ -4,41 +4,66 @@
 #  Distributed under the terms of the 3-clause BSD License.
 #-----------------------------------------------------------------------------
 
-__version__ = '0.7.1'
+
+__version__: str = '0.7.1'
+
 
 import sys
 import platform
+from typing import Callable
+
+
+#
+# Import correct the listener for the given OS
+#
+
 
 def macos_supported_version():
-    sysver = platform.mac_ver()[0] #typically 10.14.2 or 12.3
-    major = int(sysver.split('.')[0])
+    sysver: str = platform.mac_ver()[0]  # typically 10.14.2 or 12.3
+    major: int = int(sysver.split('.')[0])
     if major < 10:
         return False
     elif major >= 11:
         return True
     else:
-        minor = int(sysver.split('.')[1])
+        minor: int = int(sysver.split('.')[1])
         if minor < 14:
             return False
         else:
             return True
 
-if sys.platform == "darwin":
-    if macos_supported_version():
-        from ._mac_detect import *
-    else:
-        from ._dummy import *
-elif sys.platform == "win32" and platform.release().isdigit() and int(platform.release()) >= 10:
-    # Checks if running Windows 10 version 10.0.14393 (Anniversary Update) OR HIGHER. The getwindowsversion method returns a tuple.
-    # The third item is the build number that we can use to check if the user has a new enough version of Windows.
-    winver = int(platform.version().split('.')[2])
-    if winver >= 14393:
-        from ._windows_detect import *
-    else:
-        from ._dummy import *
+
+if sys.platform == "darwin" and macos_supported_version():
+    from ._mac_detect import *
+    Listener = MacListener
+# If running Windows 10 version 10.0.14393 (Anniversary Update) OR HIGHER.
+# The getwindowsversion method returns a tuple.
+# The third item is the build number that we can use to check if the user has a new enough version of Windows.
+elif sys.platform == "win32" and platform.release().isdigit() and int(platform.release()) >= 10 and \
+        int(platform.version().split('.')[2]) >= 14393:
+    from ._windows_detect import *
+    Listener = WindowsListener
 elif sys.platform == "linux":
     from ._linux_detect import *
+    Listener = GnomeListener
 else:
     from ._dummy import *
+    Listener = DummyListener
 
-del sys, platform
+
+#
+# Common shortcut functions
+#
+
+
+def isDark():
+    return theme() == "Dark"
+
+def isLight():
+    return theme() == "Light"
+
+def listener(callback: Callable[[str], None]) -> None:
+    Listener(callback).listen()
+
+
+del sys, platform, Callable

--- a/darkdetect/__init__.py
+++ b/darkdetect/__init__.py
@@ -12,7 +12,7 @@ import sys
 import platform
 from typing import Callable, Optional, Type
 
-from ._base_listener import BaseListener, DDTimeoutError
+from ._base_listener import BaseListener
 Listener: Type[BaseListener]
 
 #
@@ -68,7 +68,12 @@ def listener(callback: Callable[[str], None]) -> None:
     Listen for a theme change, on theme change, invoke callback(theme_name)
     :param callback: The callback to invoke
     """
-    Listener(callback).listen()
+    l = Listener(callback)
+    try:
+        l.listen()
+    except KeyboardInterrupt:
+        l.stop(0)
+        raise
 
 
 del sys, platform, Callable, Type

--- a/darkdetect/__init__.py
+++ b/darkdetect/__init__.py
@@ -10,9 +10,9 @@ __version__: str = '0.7.1'
 
 import sys
 import platform
-from typing import Callable, Type
+from typing import Callable, Optional, Type
 
-from .base import BaseListener
+from ._base_listener import BaseListener, DDTimeoutError
 Listener: Type[BaseListener]
 
 #
@@ -32,8 +32,6 @@ if sys.platform == "darwin" and macos_supported_version():
     from ._mac_detect import *
     Listener = MacListener
 # If running Windows 10 version 10.0.14393 (Anniversary Update) OR HIGHER.
-# The getwindowsversion method returns a tuple.
-# The third item is the build number that we can use to check if the user has a new enough version of Windows.
 elif sys.platform == "win32" and platform.release().isdigit() and int(platform.release()) >= 10 and \
         int(platform.version().split('.')[2]) >= 14393:
     from ._windows_detect import *
@@ -49,13 +47,27 @@ else:
 # Common shortcut functions
 #
 
-def isDark():
-    return theme() == "Dark"
+def isDark() -> Optional[bool]:
+    """
+    :return: True if the theme is Dark, False if not, None if there is no support for this OS
+    """
+    t: Optional[str] = theme()
+    return t if t is None else (t == "Dark")
 
-def isLight():
-    return theme() == "Light"
+
+def isLight() -> Optional[bool]:
+    """
+    :return: True if the theme is Light, False if not, None if there is no support for this OS
+    """
+    t: Optional[str] = theme()
+    return t if t is None else (t == "Light")
+
 
 def listener(callback: Callable[[str], None]) -> None:
+    """
+    Listen for a theme change, on theme change, invoke callback(theme_name)
+    :param callback: The callback to invoke
+    """
     Listener(callback).listen()
 
 

--- a/darkdetect/__init__.py
+++ b/darkdetect/__init__.py
@@ -10,28 +10,23 @@ __version__: str = '0.7.1'
 
 import sys
 import platform
-from typing import Callable
+from typing import Callable, Type
 
+from .base import BaseListener
+Listener: Type[BaseListener]
 
 #
 # Import correct the listener for the given OS
 #
-
 
 def macos_supported_version():
     sysver: str = platform.mac_ver()[0]  # typically 10.14.2 or 12.3
     major: int = int(sysver.split('.')[0])
     if major < 10:
         return False
-    elif major >= 11:
+    if major >= 11:
         return True
-    else:
-        minor: int = int(sysver.split('.')[1])
-        if minor < 14:
-            return False
-        else:
-            return True
-
+    return int(sysver.split('.')[1]) >= 14
 
 if sys.platform == "darwin" and macos_supported_version():
     from ._mac_detect import *
@@ -50,11 +45,9 @@ else:
     from ._dummy import *
     Listener = DummyListener
 
-
 #
 # Common shortcut functions
 #
-
 
 def isDark():
     return theme() == "Dark"
@@ -66,4 +59,4 @@ def listener(callback: Callable[[str], None]) -> None:
     Listener(callback).listen()
 
 
-del sys, platform, Callable
+del sys, platform, Callable, Type

--- a/darkdetect/__main__.py
+++ b/darkdetect/__main__.py
@@ -6,4 +6,4 @@
 
 import darkdetect
 
-print('Current theme: {}'.format(darkdetect.theme()))
+print(f"Current theme: {darkdetect.theme()}")

--- a/darkdetect/_base_listener.py
+++ b/darkdetect/_base_listener.py
@@ -11,26 +11,19 @@ class ListenerState(Enum):
     Dead = auto()
 
 
-class DDTimeoutError(RuntimeError):
-    """
-    Raised when a listener's .wait() call times out
-    """
-
-
 class BaseListener:
     """
     An abstract listener class
-    Subclasses promise that it is safe to call stop() then wait()
-    from a different thread than listen() was called in; provides two
-    threads are not both racing to call these methods
+    It is safe to call stop from a different thread than listen() was called in
+    provided multiple threads are not racing to call these methods
     """
 
-    def __init__(self, callback: Callable[[str], None]):
+    def __init__(self, callback: Optional[Callable[[str], None]]):
         """
         :param callback: The callback to use when the listener detects something
         """
         self._state: ListenerState = ListenerState.Dead
-        self.callback: Callable[[str], None] = callback
+        self.callback: Optional[Callable[[str], None]] = callback
 
     def listen(self):
         """
@@ -39,7 +32,7 @@ class BaseListener:
         if self._state == ListenerState.Listening:
             raise RuntimeError("Do not run .listen() from multiple threads concurrently")
         if self._state == ListenerState.Stopping:
-            raise RuntimeError("Call .wait() to wait for the previous listener to finish shutting down")
+            raise RuntimeError("Call .stop to wait for the previous listener to finish shutting down")
         self._state = ListenerState.Listening
         try:
             self._listen()
@@ -50,48 +43,59 @@ class BaseListener:
             self.stop()  # Just in case
             raise RuntimeError("Listen failed") from e
 
-    def stop(self):
+    def stop(self, timeout: Optional[int] = None) -> bool:
         """
-        Tells the listener to stop; may return before the listener has stopped
-        If the listener is not currently listening, this is a no-op
-        This function may be called if .listen() errors
+        Initiate the listener stop sequence, wait at most timeout seconds for it to complete.
+        After this function returns, new theme changes will not invoke callbacks.
+        Running callbacks will not be interrupted.
+        May safely be called as many times as desired.
+        Warning: stop(None) may hang until the next theme change, depending on implementation
+        :param timeout: How many seconds to wait until the listener stops; None means infinite
+        :return: True if the listener completes before the timeout expires, else False
+        """
+        if timeout is not None and timeout < 0:
+            raise RuntimeError("timeout may not be negative")
+        if self._state == ListenerState.Listening:
+            self._initiate_shutdown()
+            self._state = ListenerState.Stopping
+        if self._state == ListenerState.Stopping:
+            if self._wait_for_shutdown(timeout):
+                self._state = ListenerState.Dead
+        return self._state == ListenerState.Dead
+
+    # Non-public helper methods
+
+    def _invoke_callback(self, value: str) -> None:
+        """
+        Invoke the stored callback if the state is listening
         """
         if self._state == ListenerState.Listening:
-            self._stop()
-            self._state = ListenerState.Stopping
-
-    def wait(self, timeout: Optional[int] = None):
-        """
-        Stop the listener and waits for it to finish
-        If the listener is dead, this is a no-op
-        If this function times out, a DDTimeoutError will be raised
-        :param timeout: Ensure this function will wait at max timeout seconds if specified
-        """
-        if self._state != ListenerState.Dead:
-            self.stop()
-            self._wait(timeout)
-            self._state = ListenerState.Dead
+            c: Optional[Callable[[str], None]] = self.callback
+            if c is not None:
+                c(value)
 
     # Non-public methods
 
-    def _listen(self):
+    def _listen(self) -> None:
         """
         Start the listener
         """
         raise NotImplementedError()
 
-    def _stop(self):
+    def _initiate_shutdown(self) -> None:
         """
-        Tell the listener, do not bother waiting for it to finish stopping
-        """
-        raise NotImplementedError()
-
-    def _wait(self, timeout: Optional[int]):
-        """
-        Wait for the listener to stop
-        Promised that .stop() method will have already been called
+        Tell the listener to initiate shutdown
         """
         raise NotImplementedError()
 
+    def _wait_for_shutdown(self, timeout: Optional[int]) -> bool:
+        """
+        Wait for the listener to stop at most timeout seconds
+        Promised that _initiate_shutdown() will have already run
+        :param timeout: How many seconds to wait until the listener stops; None means infinite
+        :return: True if the listener completes before the timeout expires, else False
+        """
+        raise NotImplementedError()
 
-__all__ = ("BaseListener", "ListenerState", "DDTimeoutError")
+
+__all__ = ("BaseListener", "ListenerState")

--- a/darkdetect/_base_listener.py
+++ b/darkdetect/_base_listener.py
@@ -1,4 +1,4 @@
-from typing import Callable
+from typing import Callable, Optional
 from enum import Enum, auto
 
 
@@ -9,6 +9,12 @@ class ListenerState(Enum):
     Listening = auto()
     Stopping = auto()
     Dead = auto()
+
+
+class DDTimeoutError(RuntimeError):
+    """
+    Raised when a listener's .wait() call times out
+    """
 
 
 class BaseListener:
@@ -54,14 +60,16 @@ class BaseListener:
             self._stop()
             self._state = ListenerState.Stopping
 
-    def wait(self):
+    def wait(self, timeout: Optional[int] = None):
         """
-        Stop the listener and wait's for it to finish
+        Stop the listener and waits for it to finish
         If the listener is dead, this is a no-op
+        If this function times out, a DDTimeoutError will be raised
+        :param timeout: Ensure this function will wait at max timeout seconds if specified
         """
         if self._state != ListenerState.Dead:
             self.stop()
-            self._wait()
+            self._wait(timeout)
             self._state = ListenerState.Dead
 
     # Non-public methods
@@ -78,7 +86,7 @@ class BaseListener:
         """
         raise NotImplementedError()
 
-    def _wait(self):
+    def _wait(self, timeout: Optional[int]):
         """
         Wait for the listener to stop
         Promised that .stop() method will have already been called
@@ -86,4 +94,4 @@ class BaseListener:
         raise NotImplementedError()
 
 
-__all__ = ("BaseListener", "ListenerState")
+__all__ = ("BaseListener", "ListenerState", "DDTimeoutError")

--- a/darkdetect/_base_listener.py
+++ b/darkdetect/_base_listener.py
@@ -39,7 +39,7 @@ class BaseListener:
         except BaseException as e:
             self._on_listen_fail_base(e)
 
-    def stop(self, timeout: Optional[int] = None) -> bool:
+    def stop(self, timeout: Optional[int]) -> bool:
         """
         Initiate the listener stop sequence, wait at most timeout seconds for it to complete.
         After this function returns, new theme changes will not invoke callbacks.

--- a/darkdetect/_base_listener.py
+++ b/darkdetect/_base_listener.py
@@ -37,7 +37,7 @@ class BaseListener:
         try:
             self._listen()
         except BaseException as e:
-            self._on_listen_fail_base(e)
+            self._on_listen_fail(e)
 
     def stop(self, timeout: Optional[int]) -> bool:
         """
@@ -69,18 +69,6 @@ class BaseListener:
             if c is not None:
                 c(value)
 
-    def _on_listen_fail_base(self, why: BaseException) -> None:
-        """
-        Invoked by .listen on all failures; self._state is unknown
-        Note that .stop may still be called on a failed listener!
-        Users should only override this if catching base exceptions is required
-        For example: Emergency cleanup when a user KeyboardInterrupts a program via Ctrl-C
-        :param why: The exception caught by _listen
-        """
-        if isinstance(why, (BaseException, NotImplementedError)):
-            raise why
-        self._on_listen_fail(why)
-
     # Non-public methods
 
     def _listen(self) -> None:
@@ -106,12 +94,16 @@ class BaseListener:
         """
         raise NotImplementedError()
 
-    def _on_listen_fail(self, why: Exception) -> None:
+    def _on_listen_fail(self, why: BaseException) -> None:
         """
-        Invoked by .listen on most failures; self._state is unknown
+        Invoked by .listen on all failures; self._state is unknown
         Note that .stop may still be called on a failed listener!
+        This function must handle BaseExceptions as well!
+        For example: Emergency cleanup when a user KeyboardInterrupts a program via Ctrl-C
         :param why: The exception caught by _listen
         """
+        if isinstance(why, (BaseException, NotImplementedError)):
+            raise why
         raise RuntimeError("Listener.listen failed") from why
 
 

--- a/darkdetect/_base_listener.py
+++ b/darkdetect/_base_listener.py
@@ -45,7 +45,6 @@ class BaseListener:
         After this function returns, new theme changes will not invoke callbacks.
         Running callbacks will not be interrupted.
         May safely be called as many times as desired.
-        Warning: stop(None) may hang until the next theme change, depending on implementation
         :param timeout: How many seconds to wait until the listener stops; None means infinite
         :return: True if the listener completes before the timeout expires, else False
         """

--- a/darkdetect/_dummy.py
+++ b/darkdetect/_dummy.py
@@ -4,16 +4,17 @@
 #  Distributed under the terms of the 3-clause BSD License.
 #-----------------------------------------------------------------------------
 
-import typing
+from .base import BaseListener
+
 
 def theme():
     return None
-        
-def isDark():
-    return None
-    
-def isLight():
-    return None
 
-def listener(callback: typing.Callable[[str], None]) -> None:
-    raise NotImplementedError()
+
+class DummyListener(BaseListener):
+    """
+    A dummy listener class that implements nothing the abstract class does not
+    """
+
+
+__all__ = ("theme", "DummyListener")

--- a/darkdetect/_dummy.py
+++ b/darkdetect/_dummy.py
@@ -4,7 +4,7 @@
 #  Distributed under the terms of the 3-clause BSD License.
 #-----------------------------------------------------------------------------
 
-from .base import BaseListener
+from ._base_listener import BaseListener
 
 
 def theme():

--- a/darkdetect/_linux_detect.py
+++ b/darkdetect/_linux_detect.py
@@ -5,7 +5,7 @@
 #-----------------------------------------------------------------------------
 
 import subprocess
-from typing import Callable, Optional
+from typing import Optional
 
 from ._base_listener import BaseListener
 

--- a/darkdetect/_linux_detect.py
+++ b/darkdetect/_linux_detect.py
@@ -9,27 +9,19 @@ from typing import Callable, Optional
 
 from .base import BaseListener
 
+
 def theme():
     try:
         #Using the freedesktop specifications for checking dark mode
-        out = subprocess.run(
-            ['gsettings', 'get', 'org.gnome.desktop.interface', 'color-scheme'],
-            capture_output=True)
-        stdout = out.stdout.decode()
+        stdout = subprocess.check_output(['gsettings', 'get', 'org.gnome.desktop.interface', 'color-scheme'])
         #If not found then trying older gtk-theme method
         if len(stdout)<1:
-            out = subprocess.run(
-                ['gsettings', 'get', 'org.gnome.desktop.interface', 'gtk-theme'],
-                capture_output=True)
-            stdout = out.stdout.decode()
-    except Exception:
-        return 'Light'
+            stdout = subprocess.check_output(['gsettings', 'get', 'org.gnome.desktop.interface', 'gtk-theme'])
+    except subprocess.SubprocessError:
+        return "Light"
     # we have a string, now remove start and end quote
-    theme = stdout.lower().strip()[1:-1]
-    if '-dark' in theme.lower():
-        return 'Dark'
-    else:
-        return 'Light'
+    theme_: bytes = stdout.lower().strip()[1:-1]
+    return "Dark" if b"-dark" in theme_.lower() else "Light"
 
 
 class GnomeListener(BaseListener):

--- a/darkdetect/_mac_detect.py
+++ b/darkdetect/_mac_detect.py
@@ -1,5 +1,5 @@
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2019 Alberto Sottile
+#  Copyright (C) 2019 Alberto Sottile, Zachary Wimer
 #
 #  Distributed under the terms of the 3-clause BSD License.
 #-----------------------------------------------------------------------------
@@ -86,9 +86,14 @@ class MacListener(BaseListener):
     def _listen(self) -> None:
         if not _can_listen:
             raise NotImplementedError("Optional dependencies not found; fix this with: pip install darkdetect[macos-listener]")
-        fix = "from multiprocessing.resource_tracker import main;"
+        cmd = "import darkdetect as d; d.MacListener._listen_child()"
+        if getattr(sys, "frozen", False):
+            # This arrangement allows compatibility with pyinstaller and such (it is what multiprocessing does)
+            args = ("-B", "-s", "-S", "-E","-c", "from multiprocessing.resource_tracker import main;" + cmd)
+        else:
+            args = ("-B", "-c", cmd)
         with subprocess.Popen(
-                (sys.executable, "-c", fix + "import darkdetect as d; d.MacListener._listen_child()"),
+                (sys.executable, *args),
                 stdout=subprocess.PIPE,
                 universal_newlines=True,
                 cwd=Path(__file__).parents[1],

--- a/darkdetect/_mac_detect.py
+++ b/darkdetect/_mac_detect.py
@@ -86,8 +86,9 @@ class MacListener(BaseListener):
     def _listen(self) -> None:
         if not _can_listen:
             raise NotImplementedError("Optional dependencies not found; fix this with: pip install darkdetect[macos-listener]")
+        fix = "from multiprocessing.resource_tracker import main;"
         with subprocess.Popen(
-                (sys.executable, "-c", "import darkdetect as d; d.MacListener._listen_child()"),
+                (sys.executable, "-c", fix + "import darkdetect as d; d.MacListener._listen_child()"),
                 stdout=subprocess.PIPE,
                 universal_newlines=True,
                 cwd=Path(__file__).parents[1],

--- a/darkdetect/_mac_detect.py
+++ b/darkdetect/_mac_detect.py
@@ -59,8 +59,8 @@ def theme():
     pool = msg(NSAutoreleasePool, n('alloc'))
     pool = msg(pool, n('init'))
 
-    NSUserDefaults = C('NSUserDefaults')
-    stdUserDef = msg(NSUserDefaults, n('standardUserDefaults'))
+    NSUserDefaults_ = C('NSUserDefaults')
+    stdUserDef = msg(NSUserDefaults_, n('standardUserDefaults'))
 
     NSString = C('NSString')
 
@@ -75,10 +75,7 @@ def theme():
 
     msg(pool, n('release'))
 
-    if out is not None:
-        return out.decode('utf-8')
-    else:
-        return 'Light'
+    return "Light" if out is None else out.decode('utf-8')
 
 
 class MacListener(BaseListener):
@@ -124,7 +121,7 @@ class MacListener(BaseListener):
 
         class Observer(NSObject):
             def observeValueForKeyPath_ofObject_change_context_(
-                self, path, object, changeDescription, context
+                self, path, object_, changeDescription, context
             ):
                 result = changeDescription[NSKeyValueChangeNewKey]
                 try:

--- a/darkdetect/_windows_detect.py
+++ b/darkdetect/_windows_detect.py
@@ -3,6 +3,8 @@ from winreg import HKEY_CURRENT_USER as hkey, QueryValueEx as getSubkeyValue, Op
 import ctypes
 import ctypes.wintypes
 
+from .base import BaseListener
+
 advapi32 = ctypes.windll.advapi32
 
 # LSTATUS RegOpenKeyExA(
@@ -55,6 +57,7 @@ advapi32.RegNotifyChangeKeyValue.argtypes = (
 )
 advapi32.RegNotifyChangeKeyValue.restype = ctypes.wintypes.LONG
 
+
 def theme():
     """ Uses the Windows Registry to detect if the user is using Dark Mode """
     # Registry will return 0 if Windows is in Dark Mode and 1 if Windows is in Light Mode. This dictionary converts that output into the text that the program is expecting.
@@ -70,53 +73,50 @@ def theme():
         return None
     return valueMeaning[subkey]
 
-def isDark():
-    if theme() is not None:
-        return theme() == 'Dark'
 
-def isLight():
-    if theme() is not None:
-        return theme() == 'Light'
+class WindowsListener(BaseListener):
 
-#def listener(callback: typing.Callable[[str], None]) -> None:
-def listener(callback):
-    hKey = ctypes.wintypes.HKEY()
-    advapi32.RegOpenKeyExA(
-        ctypes.wintypes.HKEY(0x80000001), # HKEY_CURRENT_USER
-        ctypes.wintypes.LPCSTR(b'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize'),
-        ctypes.wintypes.DWORD(),
-        ctypes.wintypes.DWORD(0x00020019), # KEY_READ
-        ctypes.byref(hKey),
-    )
-
-    dwSize = ctypes.wintypes.DWORD(ctypes.sizeof(ctypes.wintypes.DWORD))
-    queryValueLast = ctypes.wintypes.DWORD()
-    queryValue = ctypes.wintypes.DWORD()
-    advapi32.RegQueryValueExA(
-        hKey,
-        ctypes.wintypes.LPCSTR(b'AppsUseLightTheme'),
-        ctypes.wintypes.LPDWORD(),
-        ctypes.wintypes.LPDWORD(),
-        ctypes.cast(ctypes.byref(queryValueLast), ctypes.wintypes.LPBYTE),
-        ctypes.byref(dwSize),
-    )
-
-    while True:
-        advapi32.RegNotifyChangeKeyValue(
-            hKey,
-            ctypes.wintypes.BOOL(True),
-            ctypes.wintypes.DWORD(0x00000004), # REG_NOTIFY_CHANGE_LAST_SET
-            ctypes.wintypes.HANDLE(None),
-            ctypes.wintypes.BOOL(False),
+    def _listen(self):
+        hKey = ctypes.wintypes.HKEY()
+        advapi32.RegOpenKeyExA(
+            ctypes.wintypes.HKEY(0x80000001), # HKEY_CURRENT_USER
+            ctypes.wintypes.LPCSTR(b'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize'),
+            ctypes.wintypes.DWORD(),
+            ctypes.wintypes.DWORD(0x00020019), # KEY_READ
+            ctypes.byref(hKey),
         )
+
+        dwSize = ctypes.wintypes.DWORD(ctypes.sizeof(ctypes.wintypes.DWORD))
+        queryValueLast = ctypes.wintypes.DWORD()
+        queryValue = ctypes.wintypes.DWORD()
         advapi32.RegQueryValueExA(
             hKey,
             ctypes.wintypes.LPCSTR(b'AppsUseLightTheme'),
             ctypes.wintypes.LPDWORD(),
             ctypes.wintypes.LPDWORD(),
-            ctypes.cast(ctypes.byref(queryValue), ctypes.wintypes.LPBYTE),
+            ctypes.cast(ctypes.byref(queryValueLast), ctypes.wintypes.LPBYTE),
             ctypes.byref(dwSize),
         )
-        if queryValueLast.value != queryValue.value:
-            queryValueLast.value = queryValue.value
-            callback('Light' if queryValue.value else 'Dark')
+
+        while True:
+            advapi32.RegNotifyChangeKeyValue(
+                hKey,
+                ctypes.wintypes.BOOL(True),
+                ctypes.wintypes.DWORD(0x00000004), # REG_NOTIFY_CHANGE_LAST_SET
+                ctypes.wintypes.HANDLE(None),
+                ctypes.wintypes.BOOL(False),
+            )
+            advapi32.RegQueryValueExA(
+                hKey,
+                ctypes.wintypes.LPCSTR(b'AppsUseLightTheme'),
+                ctypes.wintypes.LPDWORD(),
+                ctypes.wintypes.LPDWORD(),
+                ctypes.cast(ctypes.byref(queryValue), ctypes.wintypes.LPBYTE),
+                ctypes.byref(dwSize),
+            )
+            if queryValueLast.value != queryValue.value:
+                queryValueLast.value = queryValue.value
+                self.callback('Light' if queryValue.value else 'Dark')
+
+
+__all__ = ("theme", "WindowsListener",)

--- a/darkdetect/_windows_detect.py
+++ b/darkdetect/_windows_detect.py
@@ -127,14 +127,8 @@ class WindowsListener(BaseListener):
                 )
                 if queryValueLast.value != queryValue.value:
                     queryValueLast.value = queryValue.value
-                    self._callback('Light' if queryValue.value else 'Dark')
-
-    def _callback(self, theme: str):
-        """
-        A small wrapper around callback, ensures future callbacks will not be made
-        """
-        if self._state == ListenerState.Listening:
-            self.callback(theme)
+                    if self._state == ListenerState.Listening:
+                        self.callback('Light' if queryValue.value else 'Dark')
 
     def _stop(self):
         pass # Override NotSupported; stop() will set the ListenerState which is what we need

--- a/darkdetect/base.py
+++ b/darkdetect/base.py
@@ -32,7 +32,7 @@ class BaseListener:
         """
         if self._state == ListenerState.Listening:
             raise RuntimeError("Do not run .listen() from multiple threads concurrently")
-        elif self._state == ListenerState.Stopping:
+        if self._state == ListenerState.Stopping:
             raise RuntimeError("Call .wait() to wait for the previous listener to finish shutting down")
         self._state = ListenerState.Listening
         try:

--- a/darkdetect/base.py
+++ b/darkdetect/base.py
@@ -37,6 +37,9 @@ class BaseListener:
         self._state = ListenerState.Listening
         try:
             self._listen()
+        except NotImplementedError:
+            self._state = ListenerState.Dead
+            raise
         except Exception as e:
             self.stop()  # Just in case
             raise RuntimeError("Listen failed") from e

--- a/darkdetect/base.py
+++ b/darkdetect/base.py
@@ -1,0 +1,86 @@
+from typing import Callable
+from enum import Enum, auto
+
+
+class ListenerState(Enum):
+    """
+    A listener state
+    """
+    Listening = auto()
+    Stopping = auto()
+    Dead = auto()
+
+
+class BaseListener:
+    """
+    An abstract listener class
+    Subclasses promise that it is safe to call stop() then wait()
+    from a different thread than listen() was called in; provides two
+    threads are not both racing to call these methods
+    """
+
+    def __init__(self, callback: Callable[[str], None]):
+        """
+        :param callback: The callback to use when the listener detects something
+        """
+        self._state: ListenerState = ListenerState.Dead
+        self.callback: Callable[[str], None] = callback
+
+    def listen(self):
+        """
+        Start the listener if it is not already running
+        """
+        if self._state == ListenerState.Listening:
+            raise RuntimeError("Do not run .listen() from multiple threads concurrently")
+        elif self._state == ListenerState.Stopping:
+            raise RuntimeError("Call .wait() to wait for the previous listener to finish shutting down")
+        self._state = ListenerState.Listening
+        try:
+            self._listen()
+        except Exception as e:
+            self.stop()  # Just in case
+            raise RuntimeError("Listen failed") from e
+
+    def stop(self):
+        """
+        Tells the listener to stop; may return before the listener has stopped
+        If the listener is not currently listening, this is a no-op
+        This function may be called if .listen() errors
+        """
+        if self._state == ListenerState.Listening:
+            self._stop()
+            self._state = ListenerState.Stopping
+
+    def wait(self):
+        """
+        Stop the listener and wait's for it to finish
+        If the listener is dead, this is a no-op
+        """
+        if self._state != ListenerState.Dead:
+            self.stop()
+            self._wait()
+            self._state = ListenerState.Dead
+
+    # Non-public methods
+
+    def _listen(self):
+        """
+        Start the listener
+        """
+        raise NotImplementedError()
+
+    def _stop(self):
+        """
+        Tell the listener, do not bother waiting for it to finish stopping
+        """
+        raise NotImplementedError()
+
+    def _wait(self):
+        """
+        Wait for the listener to stop
+        Promised that .stop() method will have already been called
+        """
+        raise NotImplementedError()
+
+
+__all__ = ("BaseListener", "ListenerState")

--- a/darkdetect/py.typed
+++ b/darkdetect/py.typed
@@ -1,0 +1,1 @@
+PARTIAL

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,55 @@
+# `darkdetect` API
+
+The centerpiece of the API is the `Listener` class.
+Members of this class are:
+
+### The constructor: `.__init__(callback: Optional[Callable[[str], None]])`
+
+The constructor simply sets `.callback` to the given callback argument
+
+### The callback: `.callback: Optional[Callable[[str], None]]`
+
+The callback function that the listener uses.
+This function will be passed "Dark" or "Light" when the theme is changed.
+It is safe to change this during program execution.
+It is safe to set this value to `None`, while the listener will still be active,
+theme changes will not invoke the callback; though running callbacks will not be interrupted.
+This is useful if 'temporarily pausing' the listener is desired.
+
+### The listen function: `.listen()`
+
+This starts listening for theme changes, it will invoke
+`self.callback(theme_name)` when a change is detected.
+
+After a listener is stopped successfully via `.stop` (the return value must be `True`),
+it can be started again via `.listen()`.
+New listeners may be constructed, should waiting for `.stop` not be desired.
+
+### The stop function: `.stop(timeout: Optional[int]) -> bool`
+
+This function initiates the listener stop sequence and
+waits for the listener to stop for at most `timeout` seconds.
+This function returns `True` if the listener successfully
+stops before the timeout expires; otherwise `False`.
+`timeout` may be any non-negative integer or `None`.
+After `.stop` returns, regardless of the argument passed to it,
+theme changes will no longer invoke the callback
+Running callbacks will not be interrupted and may continue executing.
+
+`.stop` may safely be re-invoked any number of times.
+Calling `.stop(None)` after `.stop(0)` will work as expected.
+
+In most cases `.stop(0)` should be sufficient as this will successfully
+prevent future theme changes from generating callbacks.
+The two primary use cases for `stop` with a timeout are:
+1. Cleaning up listener resources (be that subprocesses or something else)
+2. To restart the existing listener; a listener's `.listen()` function
+   may only be re-invoked if a call to `.stop` has returned `True`.
+
+---
+
+## Wrapper Function
+
+The simplest method of using this API is the `darkdetect.listener` function, which takes a callback function as an argument.
+This function is a small wrapper around `Listener(callback).listen()`.
+_In this mode, the listener cannot be stopped_; forceful stops may not clean up resources (such as subprocesses if applicable).

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,0 +1,71 @@
+# `darkdetect` Examples
+
+### Listening with the `listener` method
+```python
+import threading
+import darkdetect
+
+t = threading.Thread(target=darkdetect.listener, args=(print,), daemon=True)
+t.start()
+```
+
+### Listening with the `Listener` class
+```python
+import threading
+import darkdetect
+
+listener = darkdetect.Listener(print)
+t = threading.Thread(target=listener.listen, daemon=True)
+t.start()
+```
+
+### Stop on user input
+```python
+import threading
+import darkdetect
+
+listener = darkdetect.Listener(print)
+t = threading.Thread(target=listener.listen, daemon=True)
+t.start()
+
+input()  # Wait for user input
+listener.stop(0)
+```
+
+### User adjustable callback
+```python
+import threading
+import darkdetect
+import time
+
+listener = darkdetect.Listener(print)
+t = threading.Thread(target=listener.listen)
+t.start()
+
+txt = ""
+while txt != "quit":
+  txt = input()
+  if txt == "print":
+    listener.callback = print
+  elif txt == "verbose":
+    listener.callback = lambda x: print(f"The theme changed to {x} as {time.time()}")
+listener.stop(0)
+
+print("Waiting for running callbacks to complete and the listener to terminate")
+if not listener.stop(timeout=5):
+  print("Callbacks/listener are still running after 5 seconds!")
+```
+
+### Possible GUI app shutdown sequence
+```python
+def shutdown(self):
+  self.listener.stop(0)  # Prevent callback from being invoked on theme changes
+  # Existing callbacks may still be running!
+  
+  self.other_shutdown_methods() # Stop other processes
+
+  # Wait a bit longer for callbacks to complete and listener to clean up
+  if self.listener.stop(timeout=5) is False:
+      # Log that listener is still running but that we are quitting anyway
+      self.logger.exception("Failed to shutdown listener / running callbacks within 5 seconds, quitting anyway.")
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ macos-listener = [ "pyobjc-framework-Cocoa; platform_system == 'Darwin'" ]
 [tool.setuptools]
 include-package-data = true
 
-[tool.setuptools.package_data]
+[tool.setuptools.package-data]
 darkdetect = ["py.typed"]
 
 [tool.setuptools.dynamic.version]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,9 @@ macos-listener = [ "pyobjc-framework-Cocoa; platform_system == 'Darwin'" ]
 [tool.setuptools]
 include-package-data = true
 
+[tool.setuptools.package_data]
+darkdetect = ["py.typed"]
+
 [tool.setuptools.dynamic.version]
 attr = "darkdetect.__version__"
 


### PR DESCRIPTION
Implements: https://github.com/albertosottile/darkdetect/issues/31

## Changes:

1. `_mac_detect.py` and other files now only need to expose only two objects, `theme` and some `BaseListener` subclass.
2. `__all__` added to `_*_detect.py` files so that only the main objects are dumped when doing `import *`
3. `py.typed` added to allow better type annotation checking via tools such as `mypy`
4. General code quality improvements, mostly stuff `pylint` complained about
5. Move `isDark()`, `isLight()`, and `def listener` out into `__init__.py` to avoid code duplication.

## Before merging:

#### Required
- [x] Test on macOS with extras installed
- [x] Test on macOS without extras installed
- [x] Test on Linux that uses Gnome (like Ubuntu 22.04)
- [x] Test on Windows
- [x] Documentation about new API

#### Optional
- [ ] If possible have `WindowsListener` `.stop(0)` be more than a no-op

## After merging:

New Issues:
- [ ] Feature Request: Support `.stop(None)` for Windows by improving Windows stop function