### PR TITLE
Use xdg-desktop-portal on Linux

### DIFF
--- a/darkdetect/_linux_detect.py
+++ b/darkdetect/_linux_detect.py
@@ -8,6 +8,28 @@ import subprocess
 
 def theme():
     try:
+        # Using the freedesktop portals for checking dark mode
+        import jeepney.io.blocking
+        import jeepney
+
+        portal = jeepney.DBusAddress(
+            object_path='/org/freedesktop/portal/desktop',
+            bus_name='org.freedesktop.portal.Desktop',
+            interface='org.freedesktop.portal.Settings'
+        )
+
+        con = jeepney.io.blocking.open_dbus_connection(bus='SESSION')
+        method = jeepney.new_method_call(portal, 'Read', 'ss', ('org.freedesktop.appearance', 'color-scheme'))
+        darkmode = con.send_and_get_reply(method).body[0][1][1]
+
+        if darkmode == 1:
+            return 'Dark'
+        else:
+            return 'Light'
+    except Exception:
+        pass
+
+    try:
         #Using the freedesktop specifications for checking dark mode
         out = subprocess.run(
             ['gsettings', 'get', 'org.gnome.desktop.interface', 'color-scheme'],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 name = "darkdetect"
 description = "Detect OS Dark Mode from Python"
 readme = "README.md"
-requires-python = ">=3.6"
+requires-python = ">=3.7"
 dynamic = [ "version" ]
 classifiers = [
     "License :: OSI Approved :: BSD License",
@@ -16,11 +16,14 @@ classifiers = [
     "Operating System :: Microsoft :: Windows :: Windows 10",
     "Operating System :: POSIX :: Linux",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11"
+]
+dependencies = [
+    "jeepney; platform_system=='Linux'"
 ]
 
 [project.license]


### PR DESCRIPTION
The xdg-desktop-portals are a set of DBus Interfaces that are implemented by every Desktop Environment. They are also available in sandboxed Environments like Flatpak or Snap. They provide a standardized way to interact with the DE. You can detect the [darkmode using portals](https://flatpak.github.io/xdg-desktop-portal/#gdbus-org.freedesktop.portal.Settings), so you no longer need gsettings, but I kept the code for backwards compatibility.

This PR adds jeepney as Dependency for Linux. I also bumped the required Python version to 3.7, as jeepney requires this and 3.6 is out of support anyway. 