### PR TITLE
Add full support for freedesktop Dark Mode specification

### DIFF
--- a/darkdetect/_linux_detect.py
+++ b/darkdetect/_linux_detect.py
@@ -1,10 +1,20 @@
 #-----------------------------------------------------------------------------
-#  Copyright (C) 2019 Alberto Sottile, Eric Larson
+#  Copyright (C) 2023 Alberto Sottile, Eric Larson, Raghav Dhingra
 #
 #  Distributed under the terms of the 3-clause BSD License.
 #-----------------------------------------------------------------------------
 
 import subprocess
+
+def _check_dbus_support():
+    command = ["dbus-send","--session","--print-reply=literal","--dest=org.freedesktop.portal.Desktop", "/org/freedesktop/portal/desktop", "org.freedesktop.portal.Setttings.Read", "string:org.freedesktop.appearance", "string:color-scheme"]
+    out = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    #stdout = str(out.stdout.decode())
+    stderr = str(out.stderr.decode())
+    if "error" in stderr.lower():
+        return False
+    else:
+        return True
 
 def theme():
     try:
@@ -45,50 +55,59 @@ def isLight():
     return theme() == 'Light'
 # def listener(callback: typing.Callable[[str], None]) -> None:
 def listener(callback):
-    _last_msg = ""
-    _last_theme = ""
-    command = ("dbus-monitor","--session","--monitor","sender=org.freedesktop.portal.Desktop, member=SettingChanged")
-    with subprocess.Popen(
-        command,
-        stdout=subprocess.PIPE,
-        universal_newlines=True,
-    ) as p:
-        for line in p.stdout:
-            #Freedesktop check
-            if "color-scheme" in _last_msg:
-                if "string" in line.strip():
-                    finalResult = line.strip("variant \n string \"")
-                    if finalResult == "prefer-dark":
-                        if _last_theme != "Dark":
+    if _check_dbus_support():
+        _last_msg = ""
+        _last_theme = ""
+        command = ("dbus-monitor","--session","--monitor","sender=org.freedesktop.portal.Desktop, member=SettingChanged")
+        with subprocess.Popen(
+            command,
+            stdout=subprocess.PIPE,
+            universal_newlines=True,
+        ) as p:
+            for line in p.stdout:
+                #Freedesktop check
+                if "color-scheme" in _last_msg:
+                    if "string" in line.strip():
+                        finalResult = line.strip("variant \n string \"")
+                        if finalResult == "prefer-dark":
+                            if _last_theme != "Dark":
+                                callback('Dark')
+                            _last_theme = "Dark"
+                        elif finalResult == "prefer-light":
+                            if _last_theme != "Light":
+                                callback('Light')
+                            _last_theme = "Light"
+                        else:
+                            if _last_theme != "Light":
+                                _last_theme = ""
+                #kde-theme check, required as there also after selecting light
+                #theme freedesktop spec is set to default
+                elif "colorscheme" in _last_msg:
+                    if "string" in line.strip():
+                        finalResult = line.strip("variant \n string \"").lower()
+                        if 'dark' in finalResult and _last_theme != "Dark":
                             callback('Dark')
-                        _last_theme = "Dark"
-                    elif finalResult == "prefer-light":
-                        if _last_theme != "Light":
+                            _last_theme = "Dark"
+                        elif _last_theme != "Light":
                             callback('Light')
-                        _last_theme = "Light"
-                    else:
-                        if _last_theme != "Light":
-                            _last_theme = ""
-            #kde-theme check, required as there also after selecting light
-            #theme freedesktop spec is set to default
-            elif "colorscheme" in _last_msg:
-                if "string" in line.strip():
-                    finalResult = line.strip("variant \n string \"").lower()
-                    if 'dark' in finalResult and _last_theme != "Dark":
-                        callback('Dark')
-                        _last_theme = "Dark"
-                    elif _last_theme != "Light":
-                        callback('Light')
-                        _last_theme = "Light"
-            #gtk-theme check
-            elif "gtk-theme" in _last_msg:
-                if "string" in line.strip():
-                    finalResult = line.strip("variant \n string \"").lower()
-                    if '-dark' in finalResult:
-                        if _last_theme != "Dark":
-                            callback('Dark')
-                        _last_theme = "Dark"
-                    elif _last_theme != "Light":
-                        callback('Light')
-                        _last_theme = "Light"
-            _last_msg = line.strip().lower()
+                            _last_theme = "Light"
+                #gtk-theme check
+                elif "gtk-theme" in _last_msg:
+                    if "string" in line.strip():
+                        finalResult = line.strip("variant \n string \"").lower()
+                        if '-dark' in finalResult:
+                            if _last_theme != "Dark":
+                                callback('Dark')
+                            _last_theme = "Dark"
+                        elif _last_theme != "Light":
+                            callback('Light')
+                            _last_theme = "Light"
+                _last_msg = line.strip().lower()
+    else:
+        with subprocess.Popen(
+            ('gsettings', 'monitor', 'org.gnome.desktop.interface', 'gtk-theme'),
+            stdout=subprocess.PIPE,
+            universal_newlines=True,
+        ) as p:
+            for line in p.stdout:
+                callback('Dark' if '-dark' in line.strip().removeprefix("gtk-theme: '").removesuffix("'").lower() else 'Light')

--- a/darkdetect/_linux_detect.py
+++ b/darkdetect/_linux_detect.py
@@ -11,15 +11,13 @@ def theme():
         #Using dbus-send command to get the theme of user using the freedesktop standards
         command = ["dbus-send","--session","--print-reply=literal","--dest=org.freedesktop.portal.Desktop", "/org/freedesktop/portal/desktop", "org.freedesktop.portal.Settings.Read", "string:org.freedesktop.appearance", "string:color-scheme"]
         out = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
-        stdout=str(out.stdout.decode())
-        if len(stdout.strip())<1:
-            pass
-        else:
-            finalResult=stdout.replace("uint32","").strip("variant \n")
+        stdout = str(out.stdout.decode())
+        if len(stdout.strip())>1:
+            finalResult = stdout.replace("uint32","").strip("variant \n")
             #0=Default, 1=prefers-dark, 2=prefers-light
-            if finalResult=="1":
+            if finalResult == "1":
                 return 'Dark'
-            elif (finalResult=="2"):
+            elif finalResult == "2":
                 return 'Light'
             else:
                 #If result Default(0) or invalid, fallback to gtk-theme method
@@ -45,13 +43,52 @@ def isDark():
 
 def isLight():
     return theme() == 'Light'
-
 # def listener(callback: typing.Callable[[str], None]) -> None:
 def listener(callback):
+    _last_msg = ""
+    _last_theme = ""
+    command = ("dbus-monitor","--session","--monitor","sender=org.freedesktop.portal.Desktop, member=SettingChanged")
     with subprocess.Popen(
-        ('gsettings', 'monitor', 'org.gnome.desktop.interface', 'gtk-theme'),
+        command,
         stdout=subprocess.PIPE,
         universal_newlines=True,
     ) as p:
         for line in p.stdout:
-            callback('Dark' if '-dark' in line.strip().removeprefix("gtk-theme: '").removesuffix("'").lower() else 'Light')
+            #Freedesktop check
+            if "color-scheme" in _last_msg:
+                if "string" in line.strip():
+                    finalResult = line.strip("variant \n string \"")
+                    if finalResult == "prefer-dark":
+                        if _last_theme != "Dark":
+                            callback('Dark')
+                        _last_theme = "Dark"
+                    elif finalResult == "prefer-light":
+                        if _last_theme != "Light":
+                            callback('Light')
+                        _last_theme = "Light"
+                    else:
+                        if _last_theme != "Light":
+                            _last_theme = ""
+            #kde-theme check, required as there also after selecting light
+            #theme freedesktop spec is set to default
+            elif "colorscheme" in _last_msg:
+                if "string" in line.strip():
+                    finalResult = line.strip("variant \n string \"").lower()
+                    if 'dark' in finalResult and _last_theme != "Dark":
+                        callback('Dark')
+                        _last_theme = "Dark"
+                    elif _last_theme != "Light":
+                        callback('Light')
+                        _last_theme = "Light"
+            #gtk-theme check
+            elif "gtk-theme" in _last_msg:
+                if "string" in line.strip():
+                    finalResult = line.strip("variant \n string \"").lower()
+                    if '-dark' in finalResult:
+                        if _last_theme != "Dark":
+                            callback('Dark')
+                        _last_theme = "Dark"
+                    elif _last_theme != "Light":
+                        callback('Light')
+                        _last_theme = "Light"
+            _last_msg = line.strip().lower()

--- a/darkdetect/_linux_detect.py
+++ b/darkdetect/_linux_detect.py
@@ -40,7 +40,7 @@ def theme():
         return 'Dark'
     else:
         return 'Light'
-print(theme())
+
 def isDark():
     return theme() == 'Dark'
 

--- a/darkdetect/_linux_detect.py
+++ b/darkdetect/_linux_detect.py
@@ -8,17 +8,30 @@ import subprocess
 
 def theme():
     try:
-        #Using the freedesktop specifications for checking dark mode
+        #Using dbus-send command to get the theme of user using the freedesktop standards
+        command = ["dbus-send","--session","--print-reply=literal","--dest=org.freedesktop.portal.Desktop", "/org/freedesktop/portal/desktop", "org.freedesktop.portal.Settings.Read", "string:org.freedesktop.appearance", "string:color-scheme"]
+        out = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
+        stdout=str(out.stdout.decode())
+        if len(stdout.strip())<1:
+            pass
+        else:
+            finalResult=stdout.replace("uint32","").strip("variant \n")
+            print(f"using {command[0]}")
+            #0=Default, 1=prefers-dark, 2=prefers-light
+            if finalResult=="1":
+                return 'Dark'
+            elif (finalResult=="2"):
+                return 'Light'
+            else:
+                #If result Default(0) or invalid, fallback to gtk-theme method
+                pass
+    except Exception:
+        pass
+    try:
         out = subprocess.run(
-            ['gsettings', 'get', 'org.gnome.desktop.interface', 'color-scheme'],
+            ['gsettings', 'get', 'org.gnome.desktop.interface', 'gtk-theme'],
             capture_output=True)
         stdout = out.stdout.decode()
-        #If not found then trying older gtk-theme method
-        if len(stdout)<1:
-            out = subprocess.run(
-                ['gsettings', 'get', 'org.gnome.desktop.interface', 'gtk-theme'],
-                capture_output=True)
-            stdout = out.stdout.decode()
     except Exception:
         return 'Light'
     # we have a string, now remove start and end quote
@@ -27,7 +40,7 @@ def theme():
         return 'Dark'
     else:
         return 'Light'
-
+print(theme())
 def isDark():
     return theme() == 'Dark'
 

--- a/darkdetect/_linux_detect.py
+++ b/darkdetect/_linux_detect.py
@@ -16,7 +16,6 @@ def theme():
             pass
         else:
             finalResult=stdout.replace("uint32","").strip("variant \n")
-            print(f"using {command[0]}")
             #0=Default, 1=prefers-dark, 2=prefers-light
             if finalResult=="1":
                 return 'Dark'


### PR DESCRIPTION
Hi there,
I have added full support for the freedesktop specifications as suggested by JackobDev in this post [https://github.com/albertosottile/darkdetect/pull/34#issuecomment-1359455980](url) except it uses the `dbus-send` command. I have also removed the older version of the code for detecting dark mode using freedesktop specifications as it was interfering with theme detection on some DEs. This code has been tested on the following distros and DEs:
```terminal
Gnome 43 (Ubuntu 22.10) ======= Working
Gnome 3.38 (Ubuntu 20.04) ===== Working (Fallback to older methods)
KDE 5.26 (Kubuntu 22.10) ====== Working
XFCE 4.16 (Fedora 37) ========= Working (Fallback to older methods)
Cinnamon 5.6.5(Linux Mint) ==== Works but buggy (default themes not having -dark in names)
```