### PR TITLE
Update _mac_detect.py

### DIFF
--- a/darkdetect/_mac_detect.py
+++ b/darkdetect/_mac_detect.py
@@ -22,7 +22,7 @@ except ModuleNotFoundError:
 
 try:
     # macOS Big Sur+ use "a built-in dynamic linker cache of all system-provided libraries"
-    appkit = ctypes.cdll.LoadLibrary('AppKit.framework/AppKit')
+    appkit = ctypes.cdll.LoadLibrary('AppKit.framework')
     objc = ctypes.cdll.LoadLibrary('libobjc.dylib')
 except OSError:
     # revert to full path for older OS versions and hardened programs


### PR DESCRIPTION
Eliminates the WARNING message from PyInstaller:
WARNING: Ignoring AppKit.framework/AppKit imported from [..]/darkdetect/_mac_detect.py - only basenames are supported with ctypes imports!